### PR TITLE
Added gradle test/set plugin when new projects are generated

### DIFF
--- a/src/main/resources/build.gradle.template
+++ b/src/main/resources/build.gradle.template
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.web3j' version '4.4.0'
     id "com.github.johnrengelman.shadow" version "5.1.0"
+    id 'org.unbroken-dome.test-sets' version '2.2.1'
+
 
 }
 
@@ -30,4 +32,7 @@ dependencies {
             "ch.qos.logback:logback-core:$logbackVersion",
             "ch.qos.logback:logback-classic:$logbackVersion"
     testImplementation "junit:junit:$junitVersion"
+}
+testSets {
+    integrationTest
 }


### PR DESCRIPTION
This PR adds unbroken-dome/gradle-testsets-plugin to generated projects. 
The purpose of this is to generate the unit tests under integrationTests/java instead of /solidity