### PR TITLE
Changed gradle override on refresh to false.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ apply {
         download {
             src "https://raw.githubusercontent.com/web3j/build-tools/master/gradle/$buildScript/build.gradle"
             dest "$rootDir/gradle/$buildScript/build.gradle"
-            overwrite true
+            overwrite false
             quiet true
             onlyIfModified true
         }


### PR DESCRIPTION
When modifying the build.gradle files under the Gradle directory on refresh the changes get reverted as the files are downloaded from github.