### PR TITLE
Fixes updater serializer

### DIFF
--- a/src/main/java/org/web3j/console/config/CliConfig.java
+++ b/src/main/java/org/web3j/console/config/CliConfig.java
@@ -109,7 +109,6 @@ public class CliConfig {
         }
     }
 
-
     public void setVersion(final String version) {
         this.version = version;
     }

--- a/src/main/java/org/web3j/console/config/CliConfig.java
+++ b/src/main/java/org/web3j/console/config/CliConfig.java
@@ -47,7 +47,9 @@ public class CliConfig {
 
     private static CliConfig getSavedConfig(File configFile) throws IOException {
         String configContents = new String(Files.readAllBytes(configFile.toPath()));
-        return new Gson().fromJson(configContents, CliConfig.class);
+        CliConfig config = new Gson().fromJson(configContents, CliConfig.class);
+        config.setVersion(Version.getVersion());
+        return config;
     }
 
     public static CliConfig getConfig(File configFile) throws IOException {
@@ -105,6 +107,11 @@ public class CliConfig {
         } else {
             return OS.UNKNOWN;
         }
+    }
+
+
+    public void setVersion(final String version) {
+        this.version = version;
     }
 
     private String version;


### PR DESCRIPTION
The deserializer for the config file will always set the CliConfig.version to the value it was at when it was first installed as GSON uses reflection to set the properties. This overrides that.