### PR TITLE
Adds gitignore for password resource files

### DIFF
--- a/src/main/java/org/web3j/console/project/AbstractProject.java
+++ b/src/main/java/org/web3j/console/project/AbstractProject.java
@@ -126,6 +126,12 @@ public abstract class AbstractProject<T extends AbstractProject<T>> {
         projectWallet =
                 new ProjectWallet(
                         ProjectUtils.generateWalletPassword(), projectStructure.getWalletPath());
+
+        ProjectWriter.writeResourceFile(
+                projectWallet.getPasswordFileName(),
+                ".gitignore",
+                projectStructure.getWalletPath());
+
         ProjectWriter.writeResourceFile(
                 projectWallet.getWalletPassword(),
                 projectWallet.getPasswordFileName(),

--- a/src/main/java/org/web3j/console/project/kotlin/KotlinProject.java
+++ b/src/main/java/org/web3j/console/project/kotlin/KotlinProject.java
@@ -69,6 +69,12 @@ public class KotlinProject extends AbstractProject<KotlinProject> implements Pro
         projectWallet =
                 new ProjectWallet(
                         ProjectUtils.generateWalletPassword(), projectStructure.getWalletPath());
+
+        ProjectWriter.writeResourceFile(
+                projectWallet.getPasswordFileName(),
+                ".gitignore",
+                projectStructure.getWalletPath());
+
         ProjectWriter.writeResourceFile(
                 projectWallet.getWalletPassword(),
                 projectWallet.getPasswordFileName(),


### PR DESCRIPTION
If a user currently initializes a Git repo with a default Java gitignore, the password to their wallet is likely to get committed with their project, unless they specifically add it to the gitigore. Whilst these wallets are highly unlikely to be used for anything sensitive, it's not a good practice to commit them.